### PR TITLE
fix: Load 100 shopware tags from the Github API

### DIFF
--- a/generate-composer-info.php
+++ b/generate-composer-info.php
@@ -1,6 +1,6 @@
 <?php
 
-$ch = curl_init('https://api.github.com/repos/shopware/platform/tags');
+$ch = curl_init('https://api.github.com/repos/shopware/platform/tags?per_page=100');
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'User-Agent: Composer Dumper'


### PR DESCRIPTION
Apparently 100 is the maximum and we need to iterate through the pages if there are more than 100 released tags (currently it is 76, so everything should be fine).

Not sure if something else breaks, since now also all old versions are considered.